### PR TITLE
Fix backward compatibility for event entities

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -2,15 +2,12 @@ name: License Compliance
 
 on:
   push:
-    branches: [ "*" ]
+    branches: '**'
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
   pull_request:
-    branches: [ "*" ]
-    paths:
-      - '**/pom.xml'
-      - 'pom.xml'
+    branches: '**'
   workflow_dispatch:
 
 permissions:
@@ -18,31 +15,10 @@ permissions:
   contents: write
 
 jobs:
-  check-licenses:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-          cache: maven
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
-
-      - name: Build with Maven and check dependencies with dash
-        run: |
-          mvn --batch-mode --update-snapshots verify -P dash
-          
-      - name: Ensure DEPENDENCIES file is reflecting the current state
-        run: |
-          mvn org.eclipse.dash:license-tool-plugin:license-check -Ddash.summary=DEPENDENCIES-gen -P dash
-          diff DEPENDENCIES DEPENDENCIES-gen
-          
-      - name: upload results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          path: 'target/dash/summary'
+  check_licences:
+    uses: eclipse-ecsp/.github/.github/workflows/workflow-licences-analysis.yml@main
+    name: Analyse Licences
+    with:
+      create-review: true
+    secrets:
+      token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -14,20 +14,20 @@ jobs:
   secret-presence:
     runs-on: ubuntu-latest
     outputs:
-      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
+      HAS_CENTRAL_SONATYPE_SECRETS: ${{ steps.secret-presence.outputs.HAS_CENTRAL_SONATYPE_SECRETS }}
     steps:
       - name: Check whether secrets exist
         id: secret-presence
         run: |
           [ ! -z "${{ secrets.GPG_PASSPHRASE }}" ] && 
           [ ! -z "${{ secrets.GPG_PRIVATE_KEY }}" ] && 
-          [ ! -z "${{ secrets.OSSRH_USERNAME }}" ] && 
-          [ ! -z "${{ secrets.OSSRH_PASSWORD }}" ]  && 
-          echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}" ] && 
+          [ ! -z "${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}" ]  && 
+          echo "HAS_CENTRAL_SONATYPE_SECRETS=true" >> $GITHUB_OUTPUT
           exit 0
           
   publish-to-sonatype:
-    name: "Publish artifacts to OSSRH Snapshots / MavenCentral"
+    name: "Publish artifacts to Maven Central"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,7 +35,7 @@ jobs:
     needs: [ secret-presence ]
 
     if: |
-      needs.secret-presence.outputs.HAS_OSSRH
+      needs.secret-presence.outputs.HAS_CENTRAL_SONATYPE_SECRETS
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,9 +58,9 @@ jobs:
           echo "<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'>
             <servers>
               <server>
-                <id>ossrh</id>
-                <username>${{ secrets.OSSRH_USERNAME }}</username>
-                <password>${{ secrets.OSSRH_PASSWORD }}</password>
+                <id>central</id>
+                <username>${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}</username>
+                <password>${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}</password>
               </server>
             </servers>
           </settings>" > $HOME/.m2/settings.xml

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.5.5, EPL-1.0 AND LGPL-2.1-only, approved, #15279
 maven/mavencentral/ch.qos.logback/logback-core/1.5.5, EPL-1.0 AND LGPL-2.1-only, approved, #15210
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #15260
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, , approved, #15194
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, Apache-2.0 AND MIT AND BSD-2-Clause, approved, #15194
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #15199
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #15189
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0 and CC-BY-2.5, approved, #15220

--- a/pom.xml
+++ b/pom.xml
@@ -120,17 +120,6 @@
         <sonar.issue.ignore.multicriteria.rule1.ruleKey>java:S101</sonar.issue.ignore.multicriteria.rule1.ruleKey>
         <sonar.issue.ignore.multicriteria.rule1.resourceKey>**/*</sonar.issue.ignore.multicriteria.rule1.resourceKey>
     </properties>
-	
-    <distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
     
     <pluginRepositories>
         <pluginRepository>
@@ -526,29 +515,21 @@
 			<properties>
                 <maven.test.skip>true</maven.test.skip>
             </properties>
-			<distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
             <build>
                 <plugins>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
-						<extensions>true</extensions>
-						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
-						</configuration>
-					</plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                            <skipPublishing>false</skipPublishing>
+                        </configuration>
+                    </plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
@@ -596,16 +577,6 @@
 			<properties>
                 <maven.test.skip>true</maven.test.skip>
             </properties>
-			<distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
             <build>
                 <plugins>
 					<plugin>

--- a/src/main/java/com/harman/ignite/domain/AbstractBlobEventData.java
+++ b/src/main/java/com/harman/ignite/domain/AbstractBlobEventData.java
@@ -1,0 +1,189 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.domain;
+
+import com.harman.ignite.entities.AbstractEventData;
+import lombok.EqualsAndHashCode;
+import org.eclipse.ecsp.domain.InvalidBlobSourceException;
+
+import java.util.Arrays;
+
+/**
+ * Abstract blob event data class.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.domain.AbstractBlobEventData} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+@EqualsAndHashCode
+public abstract class AbstractBlobEventData extends AbstractEventData {
+
+
+    /**
+     * uid.
+     */
+    private static final long serialVersionUID = -3736798123313255985L;
+    
+    /**
+     * encoding.
+     */
+    private Encoding encoding;
+    
+    /**
+     * eventSource.
+     */
+    private String eventSource;
+    
+    /**
+     * payload.
+     */
+    private byte[] payload;
+
+    /**
+     * Get the type of encoding.
+     *
+     * @return Encoding
+     */
+    public Encoding getEncoding() {
+        return encoding;
+    }
+
+    /**
+     * Set the type of encoding.
+     *
+     * @param encoding : Encoding
+     */
+    public void setEncoding(Encoding encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Get the event source.
+     *
+     * @return String
+     */
+    public String getEventSource() {
+        return eventSource;
+    }
+
+    /**
+     * Set the event source.
+     *
+     * @param eventSource : String
+     */
+    public void setEventSource(String eventSource) {
+        this.eventSource = eventSource;
+    }
+
+    /**
+     * Get the payload.
+     *
+     * @return byte[]
+     */
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    /**
+     * Set the payload.
+     *
+     * @param payload : byte[]
+     */
+    public void setPayload(byte[] payload) {
+        this.payload = payload;
+    }
+
+    @Override
+    public String toString() {
+        return "AbstractBlobEventData [encoding=" + encoding + ", eventSource="
+                + eventSource + ", payload=" + Arrays.toString(payload)
+                + "]";
+    }
+
+    /**
+     * Encoding that can be used.
+     */
+    public enum Encoding {
+        /**
+         * GPB.
+         */
+        GPB("gpb"),
+        /**
+         * JSON.
+         */
+        JSON("json");
+
+        private String encode;
+
+        /**
+         * Get the type encoding.
+         *
+         * @return String
+         */
+        public String getEncode() {
+            return encode;
+        }
+
+        Encoding(String blobSource) {
+            this.encode = blobSource;
+        }
+
+        /**
+         * Validate.
+         *
+         * @param encoding
+         *         the encoding
+         */
+        public static void validate(String encoding) {
+            boolean flag = true;
+            for (Encoding value : Encoding.values()) {
+                if (value.getEncode().equals(encoding)) {
+                    flag = false;
+                    break;
+                }
+            }
+            if (flag) {
+                throw new InvalidBlobSourceException("Invalid blob source : " + encoding + ", provided");
+            }
+        }
+    }
+}

--- a/src/main/java/com/harman/ignite/domain/BlobDataV1_0.java
+++ b/src/main/java/com/harman/ignite/domain/BlobDataV1_0.java
@@ -1,0 +1,61 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.domain;
+
+import org.eclipse.ecsp.annotations.EventMapping;
+import org.eclipse.ecsp.domain.EventID;
+import org.eclipse.ecsp.domain.Version;
+
+/**
+ * Blob data v 1.0 class.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.domain.BlobDataV1_0} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+@SuppressWarnings("checkstyle:TypeName")
+@EventMapping(id = EventID.BLOBDATA, version = Version.V1_0)
+public class BlobDataV1_0 extends AbstractBlobEventData {
+
+    private static final long serialVersionUID = 2708719978668440521L;
+
+}

--- a/src/main/java/com/harman/ignite/domain/DeviceConnStatusV1_0.java
+++ b/src/main/java/com/harman/ignite/domain/DeviceConnStatusV1_0.java
@@ -1,0 +1,147 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.domain;
+
+import com.harman.ignite.entities.AbstractEventData;
+import lombok.EqualsAndHashCode;
+import org.eclipse.ecsp.annotations.EventMapping;
+import org.eclipse.ecsp.domain.EventID;
+import org.eclipse.ecsp.domain.Version;
+
+/**
+ * Device conn status v 1.0 class.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.domain.DeviceConnStatusV1_0} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+@SuppressWarnings("checkstyle:TypeName")
+@EventMapping(id = EventID.DEVICE_CONN_STATUS, version = Version.V1_0)
+@EqualsAndHashCode
+public class DeviceConnStatusV1_0 extends AbstractEventData {
+
+    /**
+     * uid.
+     */
+    private static final long serialVersionUID = -8185364560878375079L;
+    
+    /**
+     * serviceName.
+     */
+    private String serviceName;
+    
+    /**
+     * connStatus.
+     */
+    private ConnectionStatus connStatus;
+
+    /**
+     * get service name.
+     *
+     * @return String
+     */
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    /**
+     * set service name.
+     *
+     * @param serviceName : String
+     */
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    /**
+     * get connection status.
+     *
+     * @return ConnectionStatus
+     */
+    public ConnectionStatus getConnStatus() {
+        return connStatus;
+    }
+
+    /**
+     * set connection status.
+     *
+     * @param connStatus : ConnectionStatus
+     */
+    public void setConnStatus(ConnectionStatus connStatus) {
+        this.connStatus = connStatus;
+    }
+
+    @Override
+    public String toString() {
+        return "DeviceConnStatusV1_0 [serviceName=" + serviceName + ", connStatus=" + connStatus + "]";
+    }
+
+    /**
+     * The enum Connection status.
+     */
+    public enum ConnectionStatus {
+        /**
+         * Active.
+         */
+        ACTIVE("ACTIVE"),
+        /**
+         * Inactive.
+         */
+        INACTIVE("INACTIVE");
+
+        private String connStatus;
+
+        ConnectionStatus(String connStatus) {
+            this.connStatus = connStatus;
+        }
+
+        /**
+         * get connection status.
+         *
+         * @return String
+         */
+        public String getConnectionStatus() {
+            return connStatus;
+        }
+    }
+
+}

--- a/src/main/java/com/harman/ignite/entities/AbstractEventData.java
+++ b/src/main/java/com/harman/ignite/entities/AbstractEventData.java
@@ -1,0 +1,127 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.ecsp.domain.EventAttribute;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * It represents the Data in Ignite event specification.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.AbstractEventData} instead.
+ *
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public abstract class AbstractEventData implements EventData, Serializable {
+
+    /**
+     * uid.
+     */
+    private static final long serialVersionUID = -207501751223603791L;
+    
+    /**
+     * customExtension.
+     */
+    @JsonProperty(value = EventAttribute.CUSTOM_EXTENSION)
+    private Object customExtension;
+
+    /**
+     * JsonIgnore is required to properly deserialize the custom object.
+     * If JsonIgnore annotation is not present then it will deserialize as
+     * customData:{present=false | true} because we are returning optional.
+     *
+     * @return Object
+     */
+    @JsonIgnore
+    public Optional<Object> getCustomExtension() {
+        return Optional.ofNullable(this.customExtension);
+    }
+
+    /**
+     * Set the custom extension.
+     *
+     * @param customExtension : Object
+     */
+    public void setCustomExtension(Object customExtension) {
+        this.customExtension = customExtension;
+    }
+
+    @Override
+    public String toString() {
+        return "AbstractEventData [customExtension=" + customExtension + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((customExtension != null) ? customExtension.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        AbstractEventData other = (AbstractEventData) obj;
+        if (customExtension == null) {
+            if (other.customExtension != null) {
+                return false;
+            }
+        } else if (!customExtension.equals(other.customExtension)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/harman/ignite/entities/AbstractIgniteEventBase.java
+++ b/src/main/java/com/harman/ignite/entities/AbstractIgniteEventBase.java
@@ -1,0 +1,294 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.ecsp.domain.EventAttribute;
+import org.eclipse.ecsp.domain.Version;
+
+import java.io.Serializable;
+
+/**
+ * Abstract ignite event base class.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.AbstractIgniteEventBase} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public class AbstractIgniteEventBase implements IgniteEventBase, Serializable {
+
+    /**
+     * version uid.
+     */
+    protected static final long serialVersionUID = -3920038506977633926L;
+
+    /**
+     * get schema version.
+     *
+     * @return Version
+     */
+    @JsonIgnore
+    @Override
+    public Version getSchemaVersion() {
+        return version;
+    }
+
+    /**
+     * set version.
+     *
+     * @param v : Version
+     */
+    @Override
+    public void setSchemaVersion(Version v) {
+        setVersion(v);
+    }
+
+    /**
+     * eventId.
+     */
+    @JsonProperty(value = EventAttribute.EVENTID, required = true)
+    protected String eventId;
+
+    /**
+     * version.
+     */
+    @JsonProperty(value = EventAttribute.VERSION, required = true)
+    protected Version version;
+
+    /**
+     * timestamp.
+     */
+    @JsonProperty(value = EventAttribute.TIMESTAMP, required = true)
+    protected long timestamp;
+
+    /**
+     * eventData.
+     */
+    @JsonProperty(value = "Data", required = true)
+    protected EventData eventData;
+
+    /**
+     * requestId.
+     */
+    @JsonProperty(value = EventAttribute.REQUEST_ID)
+    protected String requestId;
+
+    /**
+     * sourceDeviceId.
+     */
+    @JsonProperty(value = EventAttribute.SOURCE_DEVICE_ID)
+    protected String sourceDeviceId;
+
+    /**
+     * vehicleId.
+     */
+    @JsonProperty(value = EventAttribute.VEHICLE_ID)
+    protected String vehicleId;
+
+    /**
+     * targetDeviceId.
+     */
+    @JsonIgnore
+    @JsonProperty(value = EventAttribute.TARGET_DEVICE_ID)
+    protected String targetDeviceId;
+
+    /**
+     * tracingContext.
+     */
+    @JsonProperty(value = EventAttribute.TRC_CTX)
+    private String tracingContext;
+
+    /**
+     * get eventId.
+     *
+     * @return String
+     */
+    @Override
+    public String getEventId() {
+        return this.eventId;
+    }
+
+    /**
+     * set eventId.
+     *
+     * @param eventId : String
+     */
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    /**
+     * get version.
+     *
+     * @return Version
+     */
+    @Override
+    public Version getVersion() {
+        return this.version;
+    }
+
+    /**
+     * set version.
+     *
+     * @param version : Version
+     */
+    public void setVersion(Version version) {
+        this.version = version;
+    }
+
+    /**
+     * get timestamp.
+     *
+     * @return long
+     */
+    @Override
+    public long getTimestamp() {
+        return this.timestamp;
+    }
+
+    /**
+     * set timestamp.
+     *
+     * @param timestamp : long
+     */
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * get eventData.
+     *
+     * @return EventData
+     */
+    @Override
+    public EventData getEventData() {
+        return eventData;
+    }
+
+    /**
+     * set eventData.
+     *
+     * @param eventData : EventData
+     */
+    public void setEventData(EventData eventData) {
+        this.eventData = eventData;
+    }
+
+    /**
+     * get requestId.
+     *
+     * @return String
+     */
+    @Override
+    public String getRequestId() {
+        return requestId;
+    }
+
+    /**
+     * set requestId.
+     *
+     * @param requestId : String
+     */
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    /**
+     * One vehicle (denoted by vehicleId) can have multiple devices that are talking to the cloud (denoted by deviceId).
+     *
+     * @return deviceId
+     */
+    @Override
+    public String getSourceDeviceId() {
+        return sourceDeviceId;
+    }
+
+    /**
+     * set value for sourceDeviceId.
+     *
+     * @param sourceDeviceId : String
+     */
+    public void setSourceDeviceId(String sourceDeviceId) {
+        this.sourceDeviceId = sourceDeviceId;
+    }
+
+    /**
+     * vehicleId (VIN) - unique identification of a vehicle.
+     *
+     * @return vehicleId
+     */
+    @Override
+    public String getVehicleId() {
+        return vehicleId;
+    }
+
+    /**
+     * Set value for vehicleId.
+     *
+     * @param vehicleId : String
+     */
+    public void setVehicleId(String vehicleId) {
+        this.vehicleId = vehicleId;
+    }
+
+    /**
+     * get value for tracing context.
+     *
+     * @return String
+     */
+    @Override
+    public String getTracingContext() {
+        return tracingContext;
+    }
+
+    /**
+     * set value for tracing context.
+     *
+     * @param tracingContext : String
+     */
+    @Override
+    public void setTracingContext(String tracingContext) {
+        this.tracingContext = tracingContext;
+    }
+
+}

--- a/src/main/java/com/harman/ignite/entities/EventData.java
+++ b/src/main/java/com/harman/ignite/entities/EventData.java
@@ -1,0 +1,72 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import dev.morphia.annotations.Entity;
+
+/**
+ * This interface is embedded in IgniteEvent.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.EventData} instead.
+ *
+ * @author avadakkootko
+ *
+ *         It represents the Data in Ignite event specification.
+ *
+ *         Example: Sample dongle status event looks like as follows:
+ *
+ *         "{"EventID": "DongleStatus","Version: "1.0","Data": { "status": "attached",
+ *         "latitude": 42.2363501, "longitude": -87.9428014 }}"
+ *         ;
+ *
+ *         In the above event EventData is "Data": { "status":"attached",
+ *         "latitude": 42.2363501, "longitude": -87.9428014 }
+ *
+ *         Using @JsonRootName annotation during serialization the entire thing
+ *         will be wrapped under Data
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+@Entity
+public interface EventData {
+
+}

--- a/src/main/java/com/harman/ignite/entities/IgniteBlobEvent.java
+++ b/src/main/java/com/harman/ignite/entities/IgniteBlobEvent.java
@@ -1,0 +1,64 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+/**
+ * This class will be used by the HiveMQ plugin and Protocol Translator
+ * to convert embed the data originating from Device.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.IgniteBlobEvent} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public class IgniteBlobEvent extends AbstractIgniteEventBase {
+
+    private static final long serialVersionUID = 699520665348643942L;
+
+    @Override
+    public String toString() {
+        return "IgniteBlobEvent [getEventId()=" + getEventId() + ", getVersion()="
+                + getVersion() + ", getTimestamp()=" + getTimestamp() + ", getEventData()="
+                + getEventData() + ", getRequestId()="
+                + getRequestId() + ", getSourceDeviceId()=" + getSourceDeviceId()
+                + ", getVehicleId()=" + getVehicleId() + "]";
+    }
+}

--- a/src/main/java/com/harman/ignite/entities/IgniteDeviceAware.java
+++ b/src/main/java/com/harman/ignite/entities/IgniteDeviceAware.java
@@ -1,0 +1,69 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+/**
+ * The interface Ignite device aware.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.IgniteDeviceAware} instead.
+ *
+ * @author MaKumari
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public interface IgniteDeviceAware {
+
+    /**
+     * Type of ecu.
+     *
+     * @return EcuType
+     */
+    public String getEcuType();
+
+    /**
+     * Mqtt topic from where message is received from client.
+     *
+     * @return mqttTopic
+     */
+    public String getMqttTopic();
+
+}

--- a/src/main/java/com/harman/ignite/entities/IgniteDeviceAwareBlobEvent.java
+++ b/src/main/java/com/harman/ignite/entities/IgniteDeviceAwareBlobEvent.java
@@ -1,0 +1,139 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.ecsp.domain.EventAttribute;
+
+/**
+ * Ignite device aware blob event class.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.IgniteDeviceAwareBlobEvent} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public class IgniteDeviceAwareBlobEvent extends IgniteBlobEvent implements IgniteDeviceAware {
+
+    /**
+     * uid.
+     */
+    private static final long serialVersionUID = -3920038506977633926L;
+    
+    /**
+     * ecuType.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(value = EventAttribute.ECU_TYPE)
+    private String ecuType;
+    
+    /**
+     * mqttTopic.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(value = EventAttribute.MQTT_TOPIC)
+    private String mqttTopic;
+
+    /**
+     * Initialize with ecuType and mqttTopic.
+     *
+     * @param ecuType : String
+     *
+     * @param mqttTopic : String
+     */
+    public IgniteDeviceAwareBlobEvent(String ecuType, String mqttTopic) {
+        this.ecuType = ecuType;
+        this.mqttTopic = mqttTopic;
+    }
+
+    /**
+     * get ecuType.
+     *
+     * @return String
+     */
+    @Override
+    public String getEcuType() {
+        return ecuType;
+    }
+
+    /**
+     * set ecuType.
+     *
+     * @param ecuType : String
+     */
+    public void setEcuType(String ecuType) {
+        this.ecuType = ecuType;
+    }
+
+    /**
+     * get mqttTopic.
+     *
+     * @return String
+     */
+    @Override
+    public String getMqttTopic() {
+        return mqttTopic;
+    }
+
+    /**
+     * set mqttTopic.
+     *
+     * @param mqttTopic : String
+     */
+    public void setMqttTopic(String mqttTopic) {
+        this.mqttTopic = mqttTopic;
+    }
+
+    @Override
+    public String toString() {
+        return "IgniteDeviceAwareBlobEvent [ecuType=" + ecuType
+                + ", mqttTopic=" + mqttTopic + ", eventId=" + eventId
+                + ", version=" + version + ", timestamp=" + timestamp
+                + ", eventData=" + eventData + ", requestId=" + requestId
+                + ", sourceDeviceId=" + sourceDeviceId + ", vehicleId=" + vehicleId
+                + ", targetDeviceId=" + targetDeviceId + "]";
+    }
+
+}

--- a/src/main/java/com/harman/ignite/entities/IgniteEntity.java
+++ b/src/main/java/com/harman/ignite/entities/IgniteEntity.java
@@ -1,0 +1,70 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import dev.morphia.annotations.Entity;
+import org.eclipse.ecsp.domain.Version;
+
+/**
+ * Base contract for an entity/event in Ignite.
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.IgniteEntity} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+@Entity
+public interface IgniteEntity {
+
+    /**
+     * Get the schema version.
+     *
+     * @return Version
+     */
+    public Version getSchemaVersion();
+
+    /**
+     * Set schema version.
+     *
+     * @param version : Version
+     */
+    public void setSchemaVersion(Version version);
+}

--- a/src/main/java/com/harman/ignite/entities/IgniteEventBase.java
+++ b/src/main/java/com/harman/ignite/entities/IgniteEventBase.java
@@ -1,0 +1,129 @@
+/*
+ * *******************************************************************************
+ *
+ *  Copyright (c) 2023-24 Harman International
+ *
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ *  you may not use this file except in compliance with the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *
+ *  limitations under the License.
+ *
+ *
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  *******************************************************************************
+ */
+
+package com.harman.ignite.entities;
+
+import org.eclipse.ecsp.domain.Version;
+
+/**
+ * Contract for all events in Ignite.
+ *
+ * <p>
+ * This should not be changed frequently. This is the common abstraction shared
+ * by HiveMq-plugin and rest of the system. HiveMQ uses a special FST serializer
+ * to serialize the incoming events from device. And any changes to this
+ * interface requires recompilation and re-release of HiveMQ. Any attributes
+ * that are not relevant to HiveMQ's role in data ingestion and publish to Kafka
+ * should be added in {@link IgniteEvent} class.
+ * </p>
+ *
+ * @deprecated This class is deprecated and will be removed in future releases.
+ *     It is present only for backward compatibility with older versions of the system
+ *     and should not be used in new implementations.
+ *     Use {@link org.eclipse.ignite.entities.IgniteEventBase} instead.
+ */
+@Deprecated(
+    since = "1.1.2",
+    forRemoval = true
+)
+public interface IgniteEventBase extends IgniteEntity {
+
+    /**
+     * Identifier for this event.
+     *
+     * @return EventId
+     */
+    public String getEventId();
+
+    /**
+     * get version.
+     *
+     * @return Version
+     */
+    public Version getVersion();
+
+    /**
+     * get timestamp.
+     *
+     * @return long
+     */
+    public long getTimestamp();
+
+    /**
+     * Polymorphic data that varies from one event to another.
+     *
+     * @return EventData
+     */
+    // Removing the optional else while deserializing it wont deserialize the
+    // actual data. it will just show whether the data is present or not
+    public EventData getEventData();
+
+    /**
+     * unique across all clients to track messages.
+     *
+     * @return requestId
+     */
+    public String getRequestId();
+
+    /**
+     * One vehicle (denoted by vehicleId) can have multiple source devices
+     * that are talking to the cloud (denoted by deviceId).
+     *
+     * @return deviceId
+     */
+    public String getSourceDeviceId();
+
+    /**
+     * vehicleId - unique identification of a vehicle.
+     *
+     * @return vehicleId
+     */
+    public String getVehicleId();
+
+    /**
+     * Returns the distributed tracing context.
+     *
+     * @return TracingContext
+     */
+    public String getTracingContext();
+
+    /**
+     * Sets the distributed tracing context.
+     *
+     * @param context : Context
+     */
+    public void setTracingContext(String context);
+}


### PR DESCRIPTION
Resolves #29 

----
### Describe behaviour before the change
* Streambase library with update package names for oss release is unable to deserialize the Kafka events which have been serialized with legacy classes using FST.

### Describe behaviour after the change
* Library is now backward compatible with older components who are not yet on open source release.

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

